### PR TITLE
Add ClickHouse MCP server for OLAP analytics and data warehousing

### DIFF
--- a/servers/clickhouse/server.json
+++ b/servers/clickhouse/server.json
@@ -24,9 +24,10 @@
         {
           "name": "CLICKHOUSE_HOST",
           "description": "ClickHouse server hostname",
-          "isRequired": true,
+          "isRequired": false,
           "isSecret": false,
-          "example": "your-clickhouse-host.com"
+          "default": "0.0.0.0",
+          "example": "127.0.0.1"
         },
         {
           "name": "CLICKHOUSE_USER",
@@ -55,6 +56,22 @@
           "isRequired": false,
           "isSecret": false,
           "example": "default"
+        },
+        {
+          "name": "CLICKHOUSE_MCP_BIND_HOST",
+          "description": "The MCP transport",
+          "default": "0.0.0.0",
+          "isRequired": false,
+          "isSecret": false,
+          "example": "127.0.0.1"
+        },
+        {
+          "name": "CLICKHOUSE_MCP_SERVER_TRANSPORT",
+          "description": "The MCP transport",
+          "default": "http",
+          "isRequired": false,
+          "isSecret": false,
+          "example": "http"
         }
       ]
     }
@@ -63,8 +80,7 @@
     "ai.nimbletools.mcp/v1": {
       "container": {
         "healthCheck": {
-          "path": "/health",
-          "port": 8000
+          "enabled": false
         }
       },
       "capabilities": {
@@ -101,8 +117,8 @@
           "requires-api-key"
         ],
         "branding": {
-          "logoUrl": "https://clickhouse.com/favicon.ico",
-          "primaryColor": "#FFCC00"
+          "logoUrl": "https://static.nimbletools.ai/logos/clickhouse.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/clickhouse.png"
         },
         "documentation": {
           "readmeUrl": "https://raw.githubusercontent.com/ClickHouse/mcp-clickhouse/main/README.md"

--- a/servers/clickhouse/test.json
+++ b/servers/clickhouse/test.json
@@ -1,0 +1,25 @@
+{
+  "skip": false,
+  "environment": {
+    "CLICKHOUSE_HOST": "sql-clickhouse.clickhouse.com",
+    "CLICKHOUSE_PORT": "8443",
+    "CLICKHOUSE_USER": "demo",
+    "CLICKHOUSE_PASSWORD": "",
+    "CLICKHOUSE_SECURE": "true",
+    "CLICKHOUSE_VERIFY": "true",
+    "CLICKHOUSE_CONNECT_TIMEOUT": "30",
+    "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": "30",
+    "CLICKHOUSE_MCP_SERVER_TRANSPORT": "http", 
+    "CLICKHOUSE_MCP_BIND_HOST": "0.0.0.0"
+  }, 
+  "tests": [
+    {
+      "name": "List databases basic message",
+      "tool": "list_databases",
+      "arguments": {},
+      "expect": {
+        "type": "json"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Add ClickHouse MCP Server

Adds ClickHouse OLAP database analytics to the NimbleBrain MCP registry.

## Server Details
- **Name**: `ai.nimbletools/clickhouse`
- **Category**: Infrastructure & Data
- **Authentication**: Database credentials (host, username, password)
- **Transport**: Streamable HTTP
- **Based on**: https://github.com/ClickHouse/mcp-clickhouse

## Enterprise Value
- Real-time analytics queries on large datasets
- OLAP data warehousing
- Business intelligence and reporting
- SQL analytics at scale

## Configuration
Requires ClickHouse database connection:
- Host, port, username, password
- Optional: specific database selection

## Deployment Status
⚠️ **Requires Docker image build before deployment**

The registry entry is ready, but DevOps needs to:
1. Build Docker image from upstream ClickHouse MCP server
2. Configure with `CLICKHOUSE_MCP_SERVER_TRANSPORT=http`
3. Deploy to `docker.io/nimbletools/mcp-clickhouse:1.0.0`

Once the image is built, deploy with: `ntcli server deploy clickhouse`