### PR TITLE
Add Airtable MCP server with bases, tables, records, and bulk operations

### DIFF
--- a/servers/airtable/Dockerfile
+++ b/servers/airtable/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy server code
+COPY server.py .
+
+# Expose port
+EXPOSE 8000
+
+# Run the FastMCP server
+CMD ["python", "-m", "fastmcp", "run", "server.py", "--transport", "streamable-http", "--port", "8000"]

--- a/servers/airtable/README.md
+++ b/servers/airtable/README.md
@@ -1,0 +1,576 @@
+# Airtable MCP Server
+
+MCP server for managing Airtable bases, tables, records, and views. Perform CRUD operations, search with formulas, and manage your Airtable data programmatically.
+
+## Features
+
+- **Base Management**: List and explore accessible bases
+- **Schema Access**: Get table structures and field definitions
+- **Record Operations**: Create, read, update, and delete records
+- **Advanced Search**: Filter records using Airtable formulas
+- **Bulk Operations**: Create or update up to 10 records at once
+- **View Management**: List and work with table views
+- **Pagination**: Handle large datasets with offset-based pagination
+- **Flexible Filtering**: Sort and filter records with powerful queries
+
+## Setup
+
+### Prerequisites
+
+- Airtable account
+- Access token with appropriate scopes
+
+### Environment Variables
+
+- `AIRTABLE_ACCESS_TOKEN` (required): Your Airtable personal access token
+
+**How to create an access token:**
+1. Go to [airtable.com/create/tokens](https://airtable.com/create/tokens)
+2. Click "Create new token"
+3. Give your token a name (e.g., "MCP Server Access")
+4. Add the required scopes:
+   - `data.records:read` - Read records
+   - `data.records:write` - Create, update, delete records
+   - `schema.bases:read` - Read base schemas
+5. Add access to specific bases or select "All current and future bases"
+6. Click "Create token" and copy it immediately
+7. Store it securely as `AIRTABLE_ACCESS_TOKEN`
+
+## Available Tools
+
+### Base Management Tools
+
+#### `list_bases`
+List all accessible Airtable bases.
+
+**Example:**
+```python
+bases = await list_bases()
+```
+
+**Response includes:**
+- Base IDs
+- Base names
+- Permission levels
+
+#### `get_base_schema`
+Get complete schema for a base including tables and fields.
+
+**Parameters:**
+- `base_id` (string, required): Base ID (e.g., 'appXXXXXXXXXXXXXX')
+
+**Example:**
+```python
+schema = await get_base_schema(base_id="appAbc123")
+```
+
+**Response includes:**
+- Table IDs and names
+- Field definitions with types
+- View information
+
+### Record Listing & Search Tools
+
+#### `list_records`
+List records from a table with advanced filtering and sorting.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `fields` (list, optional): Specific fields to return
+- `filter_by_formula` (string, optional): Airtable formula filter
+- `max_records` (int, optional): Maximum records to return
+- `page_size` (int, optional): Records per page (max: 100)
+- `sort` (list, optional): Sort configuration
+- `view` (string, optional): View name or ID
+- `offset` (string, optional): Pagination offset
+
+**Example:**
+```python
+# List all records
+records = await list_records(
+    base_id="appAbc123",
+    table_id_or_name="Contacts"
+)
+
+# List with filters and sorting
+records = await list_records(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    fields=["Name", "Email", "Status"],
+    filter_by_formula="{Status} = 'Active'",
+    sort=[{"field": "Name", "direction": "asc"}],
+    max_records=50
+)
+
+# Pagination
+page1 = await list_records(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    page_size=100
+)
+# Use offset from page1 response for next page
+page2 = await list_records(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    page_size=100,
+    offset=page1["offset"]
+)
+```
+
+#### `search_records`
+Search records using Airtable formula filters.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `formula` (string, required): Airtable formula
+- `fields` (list, optional): Fields to return
+- `sort` (list, optional): Sort configuration
+- `max_records` (int, optional): Maximum records
+
+**Example:**
+```python
+# Search with complex formula
+results = await search_records(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    formula="AND({Status} = 'Active', {Age} > 25, FIND('gmail', {Email}))",
+    fields=["Name", "Email", "Age"],
+    sort=[{"field": "Age", "direction": "desc"}],
+    max_records=20
+)
+```
+
+#### `get_record`
+Get a specific record by ID.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `record_id` (string, required): Record ID (e.g., 'recXXXXXXXXXXXXXX')
+
+**Example:**
+```python
+record = await get_record(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    record_id="recDef456"
+)
+```
+
+### Record Creation & Update Tools
+
+#### `create_record`
+Create a new record in a table.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `fields` (dict, required): Field names and values
+
+**Example:**
+```python
+new_record = await create_record(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    fields={
+        "Name": "John Doe",
+        "Email": "john@example.com",
+        "Age": 30,
+        "Status": "Active"
+    }
+)
+```
+
+#### `update_record`
+Update an existing record.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `record_id` (string, required): Record ID
+- `fields` (dict, required): Fields to update
+- `replace_all` (bool, optional): If True, replace all fields (PUT). If False, merge (PATCH). Default: False
+
+**Example:**
+```python
+# Partial update (merge fields)
+updated = await update_record(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    record_id="recDef456",
+    fields={
+        "Status": "Inactive",
+        "Notes": "Updated status"
+    },
+    replace_all=False
+)
+
+# Complete replacement
+replaced = await update_record(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    record_id="recDef456",
+    fields={
+        "Name": "Jane Smith",
+        "Email": "jane@example.com",
+        "Age": 28
+    },
+    replace_all=True
+)
+```
+
+#### `delete_record`
+Delete a record from a table.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `record_id` (string, required): Record ID
+
+**Example:**
+```python
+result = await delete_record(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    record_id="recDef456"
+)
+```
+
+### Bulk Operations Tools
+
+#### `bulk_create_records`
+Create multiple records at once (up to 10 per request).
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `records` (list, required): List of record objects with fields (max: 10)
+
+**Example:**
+```python
+results = await bulk_create_records(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    records=[
+        {"Name": "Alice", "Email": "alice@example.com", "Age": 25},
+        {"Name": "Bob", "Email": "bob@example.com", "Age": 30},
+        {"Name": "Charlie", "Email": "charlie@example.com", "Age": 35}
+    ]
+)
+```
+
+#### `bulk_update_records`
+Update multiple records at once (up to 10 per request).
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+- `records` (list, required): List with 'id' and 'fields' (max: 10)
+- `replace_all` (bool, optional): Replace all fields or merge. Default: False
+
+**Example:**
+```python
+results = await bulk_update_records(
+    base_id="appAbc123",
+    table_id_or_name="Contacts",
+    records=[
+        {
+            "id": "recDef456",
+            "fields": {"Status": "Active"}
+        },
+        {
+            "id": "recGhi789",
+            "fields": {"Status": "Inactive"}
+        }
+    ],
+    replace_all=False
+)
+```
+
+### Schema & View Tools
+
+#### `get_table_fields`
+Get field definitions for a specific table.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+
+**Example:**
+```python
+fields = await get_table_fields(
+    base_id="appAbc123",
+    table_id_or_name="Contacts"
+)
+```
+
+**Response includes:**
+- Field IDs
+- Field names
+- Field types
+- Field options
+
+#### `list_views`
+List all views in a table.
+
+**Parameters:**
+- `base_id` (string, required): Base ID
+- `table_id_or_name` (string, required): Table ID or name
+
+**Example:**
+```python
+views = await list_views(
+    base_id="appAbc123",
+    table_id_or_name="Contacts"
+)
+```
+
+**Response includes:**
+- View IDs
+- View names
+- View types (grid, form, calendar, etc.)
+
+## Airtable Formula Syntax
+
+Airtable uses a formula language similar to Excel for filtering and calculations.
+
+### Basic Operators
+- **Comparison**: `=`, `!=`, `>`, `<`, `>=`, `<=`
+- **Logical**: `AND()`, `OR()`, `NOT()`
+- **Text**: `FIND()`, `SEARCH()`, `LEFT()`, `RIGHT()`, `MID()`, `LEN()`
+- **Math**: `+`, `-`, `*`, `/`, `MOD()`, `ROUND()`
+- **Date**: `TODAY()`, `NOW()`, `DATEADD()`, `DATEDIF()`, `IS_AFTER()`, `IS_BEFORE()`
+
+### Formula Examples
+
+**Filter by single condition:**
+```python
+"{Status} = 'Active'"
+```
+
+**Filter by multiple conditions:**
+```python
+"AND({Status} = 'Active', {Age} > 25)"
+```
+
+**Filter with OR:**
+```python
+"OR({Status} = 'Active', {Status} = 'Pending')"
+```
+
+**Text search:**
+```python
+"FIND('gmail', {Email})"  # Contains gmail
+```
+
+**Date filters:**
+```python
+"IS_AFTER({Created}, '2024-01-01')"
+```
+
+**Complex formula:**
+```python
+"AND(
+    OR({Status} = 'Active', {Status} = 'Pending'),
+    {Age} >= 18,
+    FIND('@company.com', {Email})
+)"
+```
+
+**Empty/not empty:**
+```python
+"{Email} != ''"  # Email is not empty
+"{Phone} = ''"   # Phone is empty
+```
+
+## Sorting Records
+
+Sort by one or more fields:
+
+```python
+# Single field
+sort=[{"field": "Name", "direction": "asc"}]
+
+# Multiple fields
+sort=[
+    {"field": "Status", "direction": "desc"},
+    {"field": "Name", "direction": "asc"}
+]
+```
+
+Directions: `asc` (ascending) or `desc` (descending)
+
+## Field Types
+
+Airtable supports various field types:
+
+### Basic Types
+- **Single line text**: Short text strings
+- **Long text**: Multi-line text
+- **Number**: Integers or decimals
+- **Checkbox**: Boolean true/false
+- **Date**: Date values
+- **Phone number**: Phone numbers
+- **Email**: Email addresses
+- **URL**: Website URLs
+
+### Selection Types
+- **Single select**: Choose one option
+- **Multiple select**: Choose multiple options
+- **Collaborator**: Airtable users
+
+### Advanced Types
+- **Attachment**: Files and images
+- **Link to another record**: Relationships
+- **Lookup**: Values from linked records
+- **Rollup**: Aggregations from linked records
+- **Formula**: Calculated values
+- **Count**: Count of linked records
+- **Rating**: Star ratings
+- **Barcode**: Barcode scanner
+- **Button**: Action buttons
+
+## Pagination
+
+Airtable returns up to 100 records per request. Use pagination for more:
+
+```python
+all_records = []
+offset = None
+
+while True:
+    response = await list_records(
+        base_id="appAbc123",
+        table_id_or_name="Contacts",
+        page_size=100,
+        offset=offset
+    )
+
+    all_records.extend(response["records"])
+
+    # Check if there are more pages
+    if "offset" in response:
+        offset = response["offset"]
+    else:
+        break  # No more records
+```
+
+## Rate Limits
+
+Airtable enforces rate limits:
+
+- **5 requests per second per base**
+- Applies to all API operations on a specific base
+- Exceeding limits returns HTTP 429 error
+
+**Best practices:**
+- Implement exponential backoff for retries
+- Use bulk operations when possible (10 records per request)
+- Cache frequently accessed data
+- Batch multiple operations together
+
+## ID Formats
+
+### Base ID
+- Format: `app` + 14 alphanumeric characters
+- Example: `appAbc123Def456Gh`
+
+### Table ID
+- Can use table ID or URL-encoded table name
+- Table ID format: `tbl` + alphanumeric
+- Example: `tblXyz789` or `Contacts`
+
+### Record ID
+- Format: `rec` + 14 alphanumeric characters
+- Example: `recDef456Ghi789Jk`
+
+### View ID
+- Format: `viw` + alphanumeric
+- Example: `viwMno012Pqr345St`
+
+## Working with Attachments
+
+Upload attachments as URLs:
+
+```python
+await create_record(
+    base_id="appAbc123",
+    table_id_or_name="Documents",
+    fields={
+        "Name": "My Document",
+        "Files": [
+            {"url": "https://example.com/file1.pdf"},
+            {"url": "https://example.com/image.jpg"}
+        ]
+    }
+)
+```
+
+## Error Handling
+
+Common error codes:
+
+- **401 Unauthorized**: Invalid or missing access token
+- **403 Forbidden**: Insufficient permissions
+- **404 Not Found**: Base, table, or record doesn't exist
+- **422 Unprocessable**: Invalid field values or formula syntax
+- **429 Too Many Requests**: Rate limit exceeded
+- **503 Service Unavailable**: Airtable service issue
+
+**Error response format:**
+```json
+{
+  "error": {
+    "type": "INVALID_REQUEST_UNKNOWN",
+    "message": "Error description"
+  }
+}
+```
+
+## Best Practices
+
+1. **Use bulk operations**: Create/update up to 10 records per request
+2. **Cache base schemas**: Schemas don't change frequently
+3. **Filter on the server**: Use formulas instead of filtering locally
+4. **Limit returned fields**: Request only needed fields
+5. **Handle rate limits**: Implement retry logic with backoff
+6. **Use views**: Leverage Airtable views for pre-filtered data
+7. **Validate data**: Check field types before creating/updating
+8. **URL-encode table names**: Use proper encoding for table names with spaces
+
+## Use Cases
+
+- **CRM Integration**: Sync customer data with Airtable
+- **Project Management**: Track tasks and milestones
+- **Content Management**: Manage blog posts and media
+- **Inventory Tracking**: Monitor stock levels and orders
+- **Event Management**: Coordinate attendees and schedules
+- **Form Processing**: Store and manage form submissions
+- **Data Migration**: Import/export data programmatically
+- **Automation**: Build workflows with Airtable as data store
+
+## API Documentation
+
+For detailed information:
+- [Airtable API Documentation](https://airtable.com/developers/web/api/introduction)
+- [Formula Field Reference](https://support.airtable.com/docs/formula-field-reference)
+- [API Authentication](https://airtable.com/developers/web/api/authentication)
+- [Rate Limits](https://airtable.com/developers/web/api/rate-limits)
+- [Field Types](https://airtable.com/developers/web/api/field-model)
+
+## Security Notes
+
+- **Never commit tokens**: Store access tokens securely
+- **Scope permissions**: Grant minimum required access
+- **Rotate tokens**: Regularly update access tokens
+- **Use HTTPS**: All API calls use HTTPS
+- **Audit access**: Review token usage regularly
+- **Revoke unused tokens**: Delete tokens no longer needed
+
+## Support
+
+- [Airtable Community](https://community.airtable.com/)
+- [Airtable Support](https://support.airtable.com/)
+- [Developer Documentation](https://airtable.com/developers/web)

--- a/servers/airtable/requirements.txt
+++ b/servers/airtable/requirements.txt
@@ -1,0 +1,4 @@
+fastmcp>=0.2.0
+httpx>=0.27.0
+python-dotenv>=1.0.0
+uvicorn>=0.30.0

--- a/servers/airtable/server.json
+++ b/servers/airtable/server.json
@@ -1,0 +1,64 @@
+{
+  "name": "ai.nimbletools/airtable",
+  "version": "1.0.0",
+  "description": "Airtable API: manage bases, tables, records, and views with flexible database operations",
+  "category": "business-finance",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/airtable",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-airtable",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://airtable.com/",
+  "license": "MIT",
+  "tags": [
+    "airtable",
+    "database",
+    "spreadsheet",
+    "crm",
+    "records",
+    "tables",
+    "data-management",
+    "collaboration",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "AIRTABLE_ACCESS_TOKEN": {
+      "description": "Airtable access token (create at https://airtable.com/create/tokens)",
+      "required": true,
+      "secret": true,
+      "example": "your_airtable_access_token_here"
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/airtable",
+      "color": "#18BFFF"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-airtable:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "250m",
+        "memory": "256Mi"
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "128Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/airtable/server.py
+++ b/servers/airtable/server.py
@@ -1,0 +1,422 @@
+"""
+Airtable MCP Server
+Provides tools for managing Airtable bases, tables, and records.
+"""
+
+import os
+from typing import Optional, List, Dict, Any
+import httpx
+from fastmcp import FastMCP
+
+# Initialize FastMCP server
+mcp = FastMCP("Airtable MCP Server")
+
+# Get API credentials from environment
+AIRTABLE_ACCESS_TOKEN = os.getenv("AIRTABLE_ACCESS_TOKEN")
+BASE_URL = "https://api.airtable.com/v0"
+
+
+def get_headers() -> dict:
+    """Get headers for Airtable API requests."""
+    if not AIRTABLE_ACCESS_TOKEN:
+        raise ValueError("AIRTABLE_ACCESS_TOKEN environment variable is required")
+    return {
+        "Authorization": f"Bearer {AIRTABLE_ACCESS_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+
+@mcp.tool()
+async def list_bases() -> dict:
+    """
+    List all accessible Airtable bases.
+
+    Returns:
+        Dictionary containing list of bases with IDs, names, and permission levels
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            "https://api.airtable.com/v0/meta/bases",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def get_base_schema(base_id: str) -> dict:
+    """
+    Get schema for a base including all tables and field definitions.
+
+    Args:
+        base_id: Base ID (starts with 'app', e.g., 'appXXXXXXXXXXXXXX')
+
+    Returns:
+        Dictionary containing base schema with tables, fields, and views
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"https://api.airtable.com/v0/meta/bases/{base_id}/tables",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def list_records(
+    base_id: str,
+    table_id_or_name: str,
+    fields: Optional[List[str]] = None,
+    filter_by_formula: Optional[str] = None,
+    max_records: Optional[int] = None,
+    page_size: Optional[int] = None,
+    sort: Optional[List[Dict[str, str]]] = None,
+    view: Optional[str] = None,
+    offset: Optional[str] = None
+) -> dict:
+    """
+    List records from a table with optional filters and sorting.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        fields: List of field names to return (optional, returns all if not specified)
+        filter_by_formula: Airtable formula to filter records (e.g., "{Status} = 'Active'")
+        max_records: Maximum number of records to return (optional)
+        page_size: Number of records per page (max: 100, default: 100)
+        sort: List of sort objects with 'field' and 'direction' (e.g., [{"field": "Name", "direction": "asc"}])
+        view: Name or ID of a view to use (optional)
+        offset: Pagination offset from previous response (optional)
+
+    Returns:
+        Dictionary containing records and optional offset for pagination
+    """
+    async with httpx.AsyncClient() as client:
+        params = {}
+
+        if fields:
+            for field in fields:
+                params[f"fields[]"] = field
+        if filter_by_formula:
+            params["filterByFormula"] = filter_by_formula
+        if max_records:
+            params["maxRecords"] = max_records
+        if page_size:
+            params["pageSize"] = page_size
+        if view:
+            params["view"] = view
+        if offset:
+            params["offset"] = offset
+        if sort:
+            for i, sort_item in enumerate(sort):
+                params[f"sort[{i}][field]"] = sort_item["field"]
+                params[f"sort[{i}][direction]"] = sort_item.get("direction", "asc")
+
+        response = await client.get(
+            f"{BASE_URL}/{base_id}/{table_id_or_name}",
+            headers=get_headers(),
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def get_record(
+    base_id: str,
+    table_id_or_name: str,
+    record_id: str
+) -> dict:
+    """
+    Get a specific record by ID.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        record_id: Record ID (starts with 'rec', e.g., 'recXXXXXXXXXXXXXX')
+
+    Returns:
+        Dictionary containing the record with all fields
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{BASE_URL}/{base_id}/{table_id_or_name}/{record_id}",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def create_record(
+    base_id: str,
+    table_id_or_name: str,
+    fields: Dict[str, Any]
+) -> dict:
+    """
+    Create a new record in a table.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        fields: Dictionary of field names and values (e.g., {"Name": "John", "Age": 30})
+
+    Returns:
+        Dictionary containing the created record with ID and fields
+    """
+    async with httpx.AsyncClient() as client:
+        data = {"fields": fields}
+
+        response = await client.post(
+            f"{BASE_URL}/{base_id}/{table_id_or_name}",
+            headers=get_headers(),
+            json=data,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def update_record(
+    base_id: str,
+    table_id_or_name: str,
+    record_id: str,
+    fields: Dict[str, Any],
+    replace_all: bool = False
+) -> dict:
+    """
+    Update an existing record.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        record_id: Record ID (starts with 'rec')
+        fields: Dictionary of field names and values to update
+        replace_all: If True, replace all fields (PUT). If False, merge fields (PATCH). Default: False
+
+    Returns:
+        Dictionary containing the updated record
+    """
+    async with httpx.AsyncClient() as client:
+        data = {"fields": fields}
+
+        if replace_all:
+            response = await client.put(
+                f"{BASE_URL}/{base_id}/{table_id_or_name}/{record_id}",
+                headers=get_headers(),
+                json=data,
+            )
+        else:
+            response = await client.patch(
+                f"{BASE_URL}/{base_id}/{table_id_or_name}/{record_id}",
+                headers=get_headers(),
+                json=data,
+            )
+
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def delete_record(
+    base_id: str,
+    table_id_or_name: str,
+    record_id: str
+) -> dict:
+    """
+    Delete a record from a table.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        record_id: Record ID (starts with 'rec')
+
+    Returns:
+        Dictionary containing deleted record ID and deletion status
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.delete(
+            f"{BASE_URL}/{base_id}/{table_id_or_name}/{record_id}",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def search_records(
+    base_id: str,
+    table_id_or_name: str,
+    formula: str,
+    fields: Optional[List[str]] = None,
+    sort: Optional[List[Dict[str, str]]] = None,
+    max_records: Optional[int] = None
+) -> dict:
+    """
+    Search records using Airtable formula filters.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        formula: Airtable formula filter (e.g., "AND({Status} = 'Active', {Age} > 25)")
+        fields: List of field names to return (optional)
+        sort: List of sort objects (optional)
+        max_records: Maximum number of records to return (optional)
+
+    Returns:
+        Dictionary containing matching records
+    """
+    return await list_records(
+        base_id=base_id,
+        table_id_or_name=table_id_or_name,
+        fields=fields,
+        filter_by_formula=formula,
+        max_records=max_records,
+        sort=sort
+    )
+
+
+@mcp.tool()
+async def bulk_create_records(
+    base_id: str,
+    table_id_or_name: str,
+    records: List[Dict[str, Any]]
+) -> dict:
+    """
+    Create multiple records at once (up to 10 per request).
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        records: List of record objects with 'fields' (max: 10 records)
+
+    Returns:
+        Dictionary containing list of created records with IDs
+    """
+    async with httpx.AsyncClient() as client:
+        # Ensure records have the correct format
+        formatted_records = [{"fields": r} if "fields" not in r else r for r in records]
+
+        data = {"records": formatted_records[:10]}  # Limit to 10 records
+
+        response = await client.post(
+            f"{BASE_URL}/{base_id}/{table_id_or_name}",
+            headers=get_headers(),
+            json=data,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def bulk_update_records(
+    base_id: str,
+    table_id_or_name: str,
+    records: List[Dict[str, Any]],
+    replace_all: bool = False
+) -> dict:
+    """
+    Update multiple records at once (up to 10 per request).
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+        records: List of record objects with 'id' and 'fields' (max: 10 records)
+        replace_all: If True, replace all fields. If False, merge fields. Default: False
+
+    Returns:
+        Dictionary containing list of updated records
+    """
+    async with httpx.AsyncClient() as client:
+        data = {"records": records[:10]}  # Limit to 10 records
+
+        if replace_all:
+            response = await client.put(
+                f"{BASE_URL}/{base_id}/{table_id_or_name}",
+                headers=get_headers(),
+                json=data,
+            )
+        else:
+            response = await client.patch(
+                f"{BASE_URL}/{base_id}/{table_id_or_name}",
+                headers=get_headers(),
+                json=data,
+            )
+
+        response.raise_for_status()
+        return response.json()
+
+
+@mcp.tool()
+async def get_table_fields(
+    base_id: str,
+    table_id_or_name: str
+) -> dict:
+    """
+    Get field definitions for a specific table.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+
+    Returns:
+        Dictionary containing field definitions with types, options, and descriptions
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"https://api.airtable.com/v0/meta/bases/{base_id}/tables",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        schema = response.json()
+
+        # Find the specific table
+        for table in schema.get("tables", []):
+            if table["id"] == table_id_or_name or table["name"] == table_id_or_name:
+                return {
+                    "table_id": table["id"],
+                    "table_name": table["name"],
+                    "fields": table.get("fields", [])
+                }
+
+        return {"error": "Table not found"}
+
+
+@mcp.tool()
+async def list_views(
+    base_id: str,
+    table_id_or_name: str
+) -> dict:
+    """
+    List all views in a table.
+
+    Args:
+        base_id: Base ID (e.g., 'appXXXXXXXXXXXXXX')
+        table_id_or_name: Table ID or URL-encoded table name
+
+    Returns:
+        Dictionary containing list of views with IDs, names, and types
+    """
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"https://api.airtable.com/v0/meta/bases/{base_id}/tables",
+            headers=get_headers(),
+        )
+        response.raise_for_status()
+        schema = response.json()
+
+        # Find the specific table
+        for table in schema.get("tables", []):
+            if table["id"] == table_id_or_name or table["name"] == table_id_or_name:
+                return {
+                    "table_id": table["id"],
+                    "table_name": table["name"],
+                    "views": table.get("views", [])
+                }
+
+        return {"error": "Table not found"}
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/servers/airtable/test.json
+++ b/servers/airtable/test.json
@@ -1,0 +1,53 @@
+{
+  "tests": [
+    {
+      "name": "List Accessible Bases",
+      "tool": "list_bases",
+      "params": {},
+      "expectedFields": [
+        "bases"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "bases"
+        }
+      ]
+    },
+    {
+      "name": "Get Base Schema",
+      "tool": "get_base_schema",
+      "params": {
+        "base_id": "appXXXXXXXXXXXXXX"
+      },
+      "expectedFields": [
+        "tables"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "tables"
+        }
+      ]
+    },
+    {
+      "name": "List Records with Filter",
+      "tool": "list_records",
+      "params": {
+        "base_id": "appXXXXXXXXXXXXXX",
+        "table_id_or_name": "Table1",
+        "max_records": 10,
+        "page_size": 10
+      },
+      "expectedFields": [
+        "records"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "records"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Add Airtable MCP Server

Comprehensive Airtable API integration for managing bases, tables, records, and views with flexible database operations.

### Features
- ✅ **Base Management** - List and explore accessible bases
- ✅ **Schema Discovery** - Get base schemas with tables and field definitions
- ✅ **Record Operations** - Create, read, update, and delete records
- ✅ **Advanced Filtering** - Search with Airtable formula syntax
- ✅ **Bulk Operations** - Create/update up to 10 records at once
- ✅ **Sorting & Pagination** - Flexible data retrieval with sorting and offsets
- ✅ **View Management** - List and work with table views
- ✅ **Field Discovery** - Get field types and configurations
- ✅ **Merge Updates** - Update records with merge or replace strategies

### Configuration
- **Authentication**: Personal access token (no OAuth)
- **Transport**: streamable-http
- **Resources**: 256Mi memory, 250m CPU
- **Rate Limits**: 5 requests/second per base

### Use Cases
- CRM and customer data management
- Project tracking and task management
- Inventory and asset management
- Content management systems
- Event planning and coordination
- Data collection and surveys
- Automation workflows
- Business operations databases

### Capabilities
- Formula-based filtering
- Multiple field types (text, number, select, date, attachment, etc.)
- Bulk operations for efficiency
- View-based data access
- Flexible sorting and pagination

### Validation
✅ All validations pass: `npm run validate-servers`