### PR TITLE
Add server.json and test.json for 27 MCP servers

### DIFF
--- a/servers/abstract-api/server.json
+++ b/servers/abstract-api/server.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/abstract-api",
+  "version": "1.0.0",
+  "description": "Abstract API: email validation, phone validation, IP geolocation, VAT validation, and utilities",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-abstract-api",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.abstractapi.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-abstract-api",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "ABSTRACT_API_KEY",
+          "description": "Abstract API key (get from https://app.abstractapi.com/)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_abstract_api_key_here"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Abstract API",
+        "category": "data-intelligence",
+        "tags": [
+          "abstract-api",
+          "validation",
+          "email",
+          "phone",
+          "ip-geolocation",
+          "vat",
+          "timezone",
+          "holidays",
+          "exchange-rates",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/abstract-api.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/abstract-api.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-abstract-api/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/abstract-api/test.json
+++ b/servers/abstract-api/test.json
@@ -1,0 +1,58 @@
+{
+  "tests": [
+    {
+      "name": "Validate Email",
+      "tool": "validate_email",
+      "params": {
+        "email": "test@example.com"
+      },
+      "expectedFields": [
+        "email",
+        "is_valid_format",
+        "deliverability"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "email"
+        }
+      ]
+    },
+    {
+      "name": "Geolocate IP",
+      "tool": "geolocate_ip",
+      "params": {
+        "ip_address": "8.8.8.8"
+      },
+      "expectedFields": [
+        "ip_address",
+        "city",
+        "country"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "ip_address"
+        }
+      ]
+    },
+    {
+      "name": "Get Exchange Rates",
+      "tool": "get_exchange_rates",
+      "params": {
+        "base": "USD",
+        "target": "EUR"
+      },
+      "expectedFields": [
+        "base",
+        "exchange_rates"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "exchange_rates"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/airtable/server.json
+++ b/servers/airtable/server.json
@@ -1,0 +1,64 @@
+{
+  "name": "ai.nimbletools/airtable",
+  "version": "1.0.0",
+  "description": "Airtable API: manage bases, tables, records, and views with flexible database operations",
+  "category": "business-finance",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/airtable",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-airtable",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://airtable.com/",
+  "license": "MIT",
+  "tags": [
+    "airtable",
+    "database",
+    "spreadsheet",
+    "crm",
+    "records",
+    "tables",
+    "data-management",
+    "collaboration",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "AIRTABLE_ACCESS_TOKEN": {
+      "description": "Airtable access token (create at https://airtable.com/create/tokens)",
+      "required": true,
+      "secret": true,
+      "example": "your_airtable_access_token_here"
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/airtable",
+      "color": "#18BFFF"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-airtable:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "250m",
+        "memory": "256Mi"
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "128Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/airtable/test.json
+++ b/servers/airtable/test.json
@@ -1,0 +1,53 @@
+{
+  "tests": [
+    {
+      "name": "List Accessible Bases",
+      "tool": "list_bases",
+      "params": {},
+      "expectedFields": [
+        "bases"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "bases"
+        }
+      ]
+    },
+    {
+      "name": "Get Base Schema",
+      "tool": "get_base_schema",
+      "params": {
+        "base_id": "appXXXXXXXXXXXXXX"
+      },
+      "expectedFields": [
+        "tables"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "tables"
+        }
+      ]
+    },
+    {
+      "name": "List Records with Filter",
+      "tool": "list_records",
+      "params": {
+        "base_id": "appXXXXXXXXXXXXXX",
+        "table_id_or_name": "Table1",
+        "max_records": 10,
+        "page_size": 10
+      },
+      "expectedFields": [
+        "records"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "records"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/alpha-vantage/server.json
+++ b/servers/alpha-vantage/server.json
@@ -1,0 +1,64 @@
+{
+  "name": "ai.nimbletools/alpha-vantage",
+  "version": "1.0.0",
+  "description": "Alpha Vantage API: stocks, forex, crypto, technical indicators, and fundamental data",
+  "category": "data-intelligence",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/alpha-vantage",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-alpha-vantage",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.alphavantage.co/",
+  "license": "MIT",
+  "tags": [
+    "stocks",
+    "finance",
+    "forex",
+    "cryptocurrency",
+    "technical-analysis",
+    "market-data",
+    "trading",
+    "indicators",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "ALPHAVANTAGE_API_KEY": {
+      "description": "Alpha Vantage API key (get from https://www.alphavantage.co/support/#api-key)",
+      "required": true,
+      "secret": true,
+      "example": "your_alphavantage_api_key_here"
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/google-finance",
+      "color": "#0F9D58"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-alpha-vantage:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "250m",
+        "memory": "256Mi"
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "128Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/alpha-vantage/test.json
+++ b/servers/alpha-vantage/test.json
@@ -1,0 +1,65 @@
+{
+  "tests": [
+    {
+      "name": "Get Stock Quote for AAPL",
+      "tool": "get_stock_quote",
+      "params": {
+        "symbol": "AAPL"
+      },
+      "expectedFields": [
+        "Global Quote"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "Global Quote"
+        },
+        {
+          "type": "exists",
+          "path": "Global Quote.01. symbol"
+        },
+        {
+          "type": "exists",
+          "path": "Global Quote.05. price"
+        }
+      ]
+    },
+    {
+      "name": "Search Symbol for Apple",
+      "tool": "search_symbol",
+      "params": {
+        "keywords": "Apple"
+      },
+      "expectedFields": [
+        "bestMatches"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "bestMatches"
+        }
+      ]
+    },
+    {
+      "name": "Get Forex Rate USD to EUR",
+      "tool": "get_forex_rate",
+      "params": {
+        "from_currency": "USD",
+        "to_currency": "EUR"
+      },
+      "expectedFields": [
+        "Realtime Currency Exchange Rate"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "Realtime Currency Exchange Rate"
+        },
+        {
+          "type": "exists",
+          "path": "Realtime Currency Exchange Rate.5. Exchange Rate"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/asana/server.json
+++ b/servers/asana/server.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/asana",
+  "version": "1.0.0",
+  "description": "Asana API: task management, project tracking, team collaboration, and workflow automation",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-asana",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://asana.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-asana",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "ASANA_PERSONAL_ACCESS_TOKEN",
+          "description": "Asana Personal Access Token (get one at app.asana.com/0/my-apps)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "0/1234567890abcdef..."
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Asana",
+        "category": "business-finance",
+        "tags": [
+          "asana",
+          "tasks",
+          "project-management",
+          "collaboration",
+          "workflow",
+          "productivity",
+          "teams",
+          "planning",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/asana.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/asana.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-asana/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/asana/test.json
+++ b/servers/asana/test.json
@@ -1,0 +1,54 @@
+{
+  "tests": [
+    {
+      "name": "List Workspaces",
+      "tool": "list_workspaces",
+      "params": {
+        "limit": 10
+      },
+      "expectedFields": [
+        "data"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "data"
+        }
+      ]
+    },
+    {
+      "name": "List Projects",
+      "tool": "list_projects",
+      "params": {
+        "workspace": "1234567890",
+        "limit": 10
+      },
+      "expectedFields": [
+        "data"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "data"
+        }
+      ]
+    },
+    {
+      "name": "List Tasks",
+      "tool": "list_tasks",
+      "params": {
+        "workspace": "1234567890",
+        "limit": 10
+      },
+      "expectedFields": [
+        "data"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "data"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/brave-search/server.json
+++ b/servers/brave-search/server.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/brave-search",
+  "version": "1.0.0",
+  "description": "Brave Search API: web, news, images, videos, local search, and AI-powered summaries",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-brave-search",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://brave.com/search/api/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-brave-search",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "BRAVE_API_KEY",
+          "description": "Brave Search API key (get free key at brave.com/search/api/)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "BSA..."
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Brave Search",
+        "category": "data-intelligence",
+        "tags": [
+          "search",
+          "web-search",
+          "news",
+          "images",
+          "videos",
+          "local-search",
+          "privacy",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/brave.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/brave.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-brave-search/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/brave-search/test.json
+++ b/servers/brave-search/test.json
@@ -1,0 +1,42 @@
+{
+  "environment": {
+    "BRAVE_API_KEY": "${BRAVE_API_KEY}"
+  },
+  "tests": [
+    {
+      "name": "Test web search",
+      "tool": "web_search",
+      "arguments": {
+        "query": "artificial intelligence",
+        "count": 5
+      },
+      "expect": {
+        "type": "object",
+        "hasKeys": ["web"]
+      }
+    },
+    {
+      "name": "Test news search",
+      "tool": "news_search",
+      "arguments": {
+        "query": "technology news",
+        "count": 5
+      },
+      "expect": {
+        "type": "object",
+        "hasKeys": ["results"]
+      }
+    },
+    {
+      "name": "Test search suggestions",
+      "tool": "suggest",
+      "arguments": {
+        "query": "python"
+      },
+      "expect": {
+        "type": "array",
+        "minLength": 1
+      }
+    }
+  ]
+}

--- a/servers/claude/server.json
+++ b/servers/claude/server.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/claude",
+  "version": "1.0.0",
+  "description": "Anthropic Claude API: messages, vision, multi-turn chat, token counting, and model comparison",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-claude",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.anthropic.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-claude",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "ANTHROPIC_API_KEY",
+          "description": "Anthropic API key for accessing Claude models (get key at console.anthropic.com/settings/keys)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "sk-ant-..."
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "512Mi",
+          "cpu": "500m"
+        },
+        "requests": {
+          "memory": "256Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Claude",
+        "category": "ai-ml",
+        "tags": [
+          "anthropic",
+          "claude",
+          "claude-3",
+          "claude-35",
+          "chat",
+          "vision",
+          "conversation",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/claude.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/claude.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-claude/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/claude/test.json
+++ b/servers/claude/test.json
@@ -1,0 +1,30 @@
+{
+  "environment": {
+    "ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY}"
+  },
+  "tests": [
+    {
+      "name": "Test simple chat",
+      "tool": "chat",
+      "arguments": {
+        "prompt": "Say 'test successful' and nothing else",
+        "max_tokens": 20
+      },
+      "expect": {
+        "type": "text",
+        "contains": "test successful"
+      }
+    },
+    {
+      "name": "Test get model info",
+      "tool": "get_model_info",
+      "arguments": {
+        "model": "claude-3-5-sonnet-20241022"
+      },
+      "expect": {
+        "type": "object",
+        "hasKeys": ["name", "context_window", "supports_vision"]
+      }
+    }
+  ]
+}

--- a/servers/clickup/server.json
+++ b/servers/clickup/server.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/clickup",
+  "version": "1.0.0",
+  "description": "ClickUp API: project management, tasks, time tracking, goals, and team collaboration",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-clickup",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://clickup.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-clickup",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "CLICKUP_API_TOKEN",
+          "description": "ClickUp API token (get from https://app.clickup.com/settings/apps)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "pk_..."
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "ClickUp",
+        "category": "business-finance",
+        "tags": [
+          "clickup",
+          "project-management",
+          "tasks",
+          "time-tracking",
+          "goals",
+          "collaboration",
+          "productivity",
+          "agile",
+          "scrum",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/clickup.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/clickup.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-clickup/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/clickup/test.json
+++ b/servers/clickup/test.json
@@ -1,0 +1,50 @@
+{
+  "tests": [
+    {
+      "name": "List Workspaces",
+      "tool": "list_workspaces",
+      "params": {},
+      "expectedFields": [
+        "teams"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "teams"
+        }
+      ]
+    },
+    {
+      "name": "List Spaces",
+      "tool": "list_spaces",
+      "params": {
+        "workspace_id": "test_workspace_id"
+      },
+      "expectedFields": [
+        "spaces"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "spaces"
+        }
+      ]
+    },
+    {
+      "name": "List Tasks",
+      "tool": "list_tasks",
+      "params": {
+        "list_id": "test_list_id"
+      },
+      "expectedFields": [
+        "tasks"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "tasks"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/coingecko/server.json
+++ b/servers/coingecko/server.json
@@ -1,0 +1,65 @@
+{
+  "name": "ai.nimbletools/coingecko",
+  "version": "1.0.0",
+  "description": "CoinGecko API: cryptocurrency prices, market data, trending coins, and global market stats",
+  "category": "data-intelligence",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/coingecko",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-coingecko",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.coingecko.com/",
+  "license": "MIT",
+  "tags": [
+    "cryptocurrency",
+    "crypto",
+    "bitcoin",
+    "ethereum",
+    "market-data",
+    "prices",
+    "trading",
+    "defi",
+    "nft",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "COINGECKO_API_KEY": {
+      "description": "CoinGecko API key (get from https://www.coingecko.com/en/api/pricing)",
+      "required": true,
+      "secret": true,
+      "example": "your_coingecko_api_key_here"
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/bitcoin",
+      "color": "#F7931A"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-coingecko:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "250m",
+        "memory": "256Mi"
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "128Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/coingecko/test.json
+++ b/servers/coingecko/test.json
@@ -1,0 +1,64 @@
+{
+  "tests": [
+    {
+      "name": "Get Bitcoin Price",
+      "tool": "get_coin_price",
+      "params": {
+        "ids": "bitcoin",
+        "vs_currencies": "usd,eur",
+        "include_market_cap": true,
+        "include_24hr_vol": true,
+        "include_24hr_change": true
+      },
+      "expectedFields": [
+        "bitcoin"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "bitcoin.usd"
+        },
+        {
+          "type": "exists",
+          "path": "bitcoin.eur"
+        }
+      ]
+    },
+    {
+      "name": "Get Trending Coins",
+      "tool": "get_trending_coins",
+      "params": {},
+      "expectedFields": [
+        "coins"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "coins"
+        }
+      ]
+    },
+    {
+      "name": "Get Global Market Data",
+      "tool": "get_global_market_data",
+      "params": {},
+      "expectedFields": [
+        "data"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "data"
+        },
+        {
+          "type": "exists",
+          "path": "data.total_market_cap"
+        },
+        {
+          "type": "exists",
+          "path": "data.total_volume"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/context7/server.json
+++ b/servers/context7/server.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/context7",
+  "version": "1.0.0",
+  "description": "Context7 API: search docs, get examples, explain code, API references, and troubleshoot errors",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-context7",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://context7.com",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-context7",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "CONTEXT7_API_KEY",
+          "description": "Context7 API key for accessing documentation (get key at context7.com/api)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_context7_api_key_here"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Context7",
+        "category": "developer-tools",
+        "tags": [
+          "documentation",
+          "code-examples",
+          "api-reference",
+          "troubleshooting",
+          "migration",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/context7.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/context7.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-context7/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/context7/test.json
+++ b/servers/context7/test.json
@@ -1,0 +1,30 @@
+{
+  "environment": {
+    "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+  },
+  "tests": [
+    {
+      "name": "Test documentation search",
+      "tool": "search_documentation",
+      "arguments": {
+        "query": "React hooks",
+        "limit": 5
+      },
+      "expect": {
+        "type": "array",
+        "minLength": 1
+      }
+    },
+    {
+      "name": "Test list supported libraries",
+      "tool": "list_supported_libraries",
+      "arguments": {
+        "language": "javascript"
+      },
+      "expect": {
+        "type": "array",
+        "minLength": 1
+      }
+    }
+  ]
+}

--- a/servers/deepl/server.json
+++ b/servers/deepl/server.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/deepl",
+  "version": "1.0.0",
+  "description": "DeepL API: professional translation for 30+ languages with document support and glossaries",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-deepl",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.deepl.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-deepl",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "DEEPL_API_KEY",
+          "description": "DeepL API key (get from https://www.deepl.com/pro-api)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_deepl_api_key:fx"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "DeepL",
+        "category": "communication-collaboration",
+        "tags": [
+          "deepl",
+          "translation",
+          "languages",
+          "localization",
+          "i18n",
+          "multilingual",
+          "documents",
+          "glossary",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/deepl.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/deepl.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-deepl/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/deepl/test.json
+++ b/servers/deepl/test.json
@@ -1,0 +1,54 @@
+{
+  "tests": [
+    {
+      "name": "Translate Text EN to DE",
+      "tool": "translate_text",
+      "params": {
+        "text": "Hello, world!",
+        "target_lang": "DE",
+        "source_lang": "EN"
+      },
+      "expectedFields": [
+        "translations"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "translations"
+        }
+      ]
+    },
+    {
+      "name": "Detect Language",
+      "tool": "detect_language",
+      "params": {
+        "text": "Bonjour le monde"
+      },
+      "expectedFields": [
+        "detected_language"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "detected_language"
+        }
+      ]
+    },
+    {
+      "name": "List Languages",
+      "tool": "list_languages",
+      "params": {
+        "language_type": "target"
+      },
+      "expectedFields": [
+        "languages"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "languages"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/gemini/server.json
+++ b/servers/gemini/server.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/gemini",
+  "version": "1.0.0",
+  "description": "Google Gemini API: multimodal AI for text, images, video, audio, and PDFs with 2M token context",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-gemini",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://ai.google.dev/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-gemini",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "GEMINI_API_KEY",
+          "description": "Google Gemini API key (get from https://aistudio.google.com/app/apikey)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "AIza..."
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "512Mi",
+          "cpu": "500m"
+        },
+        "requests": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Google Gemini",
+        "category": "ai-ml",
+        "tags": [
+          "google",
+          "gemini",
+          "ai",
+          "llm",
+          "multimodal",
+          "vision",
+          "video-analysis",
+          "function-calling",
+          "embeddings",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/gemini.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/gemini.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-gemini/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/gemini/test.json
+++ b/servers/gemini/test.json
@@ -1,0 +1,58 @@
+{
+  "tests": [
+    {
+      "name": "Generate Text",
+      "tool": "generate_text",
+      "params": {
+        "prompt": "Write a haiku about coding",
+        "model": "gemini-1.5-flash-latest",
+        "temperature": 0.7,
+        "max_output_tokens": 100
+      },
+      "expectedFields": [
+        "candidates"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "candidates"
+        },
+        {
+          "type": "exists",
+          "path": "candidates[0].content.parts[0].text"
+        }
+      ]
+    },
+    {
+      "name": "Count Tokens",
+      "tool": "count_tokens",
+      "params": {
+        "text": "Hello, how are you today?",
+        "model": "gemini-1.5-flash-latest"
+      },
+      "expectedFields": [
+        "totalTokens"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "totalTokens"
+        }
+      ]
+    },
+    {
+      "name": "List Models",
+      "tool": "list_models",
+      "params": {},
+      "expectedFields": [
+        "models"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "models"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/gitlab/server.json
+++ b/servers/gitlab/server.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/gitlab",
+  "version": "1.0.0",
+  "description": "GitLab API: repos, issues, merge requests, CI/CD pipelines, and DevOps automation",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-gitlab",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://gitlab.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-gitlab",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "GITLAB_PERSONAL_ACCESS_TOKEN",
+          "description": "GitLab Personal Access Token with api scope (get one at gitlab.com/-/profile/personal_access_tokens)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "glpat-xxxxxxxxxxxxxxxxxxxx"
+        },
+        {
+          "name": "GITLAB_URL",
+          "description": "GitLab instance URL (defaults to gitlab.com)",
+          "isRequired": false,
+          "isSecret": false,
+          "example": "https://gitlab.com"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "GitLab",
+        "category": "developer-tools",
+        "tags": [
+          "gitlab",
+          "version-control",
+          "git",
+          "devops",
+          "ci-cd",
+          "merge-requests",
+          "pipelines",
+          "collaboration",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/gitlab.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/gitlab.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-gitlab/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/gitlab/test.json
+++ b/servers/gitlab/test.json
@@ -1,0 +1,44 @@
+{
+  "tests": [
+    {
+      "name": "List Projects",
+      "tool": "list_projects",
+      "params": {
+        "per_page": 10
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "array"
+        }
+      ]
+    },
+    {
+      "name": "List Issues",
+      "tool": "list_issues",
+      "params": {
+        "per_page": 10
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "array"
+        }
+      ]
+    },
+    {
+      "name": "List Pipelines (requires project)",
+      "tool": "list_pipelines",
+      "params": {
+        "project_id": "278964",
+        "per_page": 10
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "array"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/huggingface/server.json
+++ b/servers/huggingface/server.json
@@ -1,0 +1,65 @@
+{
+  "name": "ai.nimbletools/huggingface",
+  "version": "1.0.0",
+  "description": "Hugging Face API: LLMs, image generation, text classification, embeddings, and 200,000+ models",
+  "category": "ai-ml",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/huggingface",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-huggingface",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://huggingface.co/",
+  "license": "MIT",
+  "tags": [
+    "huggingface",
+    "llm",
+    "machine-learning",
+    "text-generation",
+    "image-generation",
+    "stable-diffusion",
+    "embeddings",
+    "nlp",
+    "computer-vision",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "HUGGINGFACE_API_TOKEN": {
+      "description": "Hugging Face API token (get from https://huggingface.co/settings/tokens)",
+      "required": true,
+      "secret": true,
+      "example": "hf_..."
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/huggingface",
+      "color": "#FFD21E"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-huggingface:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "500m",
+        "memory": "512Mi"
+      },
+      "requests": {
+        "cpu": "250m",
+        "memory": "256Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/huggingface/test.json
+++ b/servers/huggingface/test.json
@@ -1,0 +1,64 @@
+{
+  "tests": [
+    {
+      "name": "Text Generation",
+      "tool": "text_generation",
+      "params": {
+        "prompt": "Once upon a time",
+        "model_id": "mistralai/Mistral-7B-Instruct-v0.3",
+        "max_new_tokens": 50,
+        "temperature": 0.7
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "[0].generated_text"
+        }
+      ]
+    },
+    {
+      "name": "Text Classification",
+      "tool": "text_classification",
+      "params": {
+        "text": "I love this product! It's amazing!",
+        "model_id": "distilbert-base-uncased-finetuned-sst-2-english"
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "[0]"
+        },
+        {
+          "type": "exists",
+          "path": "[0][0].label"
+        },
+        {
+          "type": "exists",
+          "path": "[0][0].score"
+        }
+      ]
+    },
+    {
+      "name": "Sentence Similarity",
+      "tool": "sentence_similarity",
+      "params": {
+        "source_sentence": "That is a happy person",
+        "sentences": [
+          "That is a happy dog",
+          "That is a very happy person",
+          "Today is a sunny day"
+        ],
+        "model_id": "sentence-transformers/all-MiniLM-L6-v2"
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "[0]"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/linear/server.json
+++ b/servers/linear/server.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/linear",
+  "version": "1.0.0",
+  "description": "Linear API: issue tracking, project management, sprints, roadmaps, and team collaboration",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-linear",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://linear.app/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-linear",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "LINEAR_API_KEY",
+          "description": "Linear API key (get from https://linear.app/settings/api)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "lin_api_xxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Linear",
+        "category": "developer-tools",
+        "tags": [
+          "linear",
+          "issue-tracking",
+          "project-management",
+          "agile",
+          "sprints",
+          "roadmap",
+          "collaboration",
+          "graphql",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/linear.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/linear.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-linear/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/linear/test.json
+++ b/servers/linear/test.json
@@ -1,0 +1,50 @@
+{
+  "tests": [
+    {
+      "name": "List Issues",
+      "tool": "list_issues",
+      "params": {
+        "first": 10
+      },
+      "expectedFields": [
+        "data"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "data"
+        }
+      ]
+    },
+    {
+      "name": "List Projects",
+      "tool": "list_projects",
+      "params": {
+        "first": 10
+      },
+      "expectedFields": [
+        "data"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "data"
+        }
+      ]
+    },
+    {
+      "name": "List Teams",
+      "tool": "list_teams",
+      "params": {},
+      "expectedFields": [
+        "data"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "data"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/mailchimp/server.json
+++ b/servers/mailchimp/server.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/mailchimp",
+  "version": "1.0.0",
+  "description": "Mailchimp API: email marketing, audience management, campaigns, and analytics",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-mailchimp",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://mailchimp.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-mailchimp",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "MAILCHIMP_API_KEY",
+          "description": "Mailchimp API key with data center (get from https://mailchimp.com/help/about-api-keys)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_api_key-us1"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Mailchimp",
+        "category": "communication-collaboration",
+        "tags": [
+          "mailchimp",
+          "email",
+          "marketing",
+          "campaigns",
+          "newsletters",
+          "automation",
+          "audience",
+          "analytics",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/mailchimp.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/mailchimp.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-mailchimp/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/mailchimp/test.json
+++ b/servers/mailchimp/test.json
@@ -1,0 +1,55 @@
+{
+  "tests": [
+    {
+      "name": "List Audiences",
+      "tool": "list_audiences",
+      "params": {
+        "count": 10
+      },
+      "expectedFields": [
+        "lists",
+        "total_items"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "lists"
+        }
+      ]
+    },
+    {
+      "name": "List Campaigns",
+      "tool": "list_campaigns",
+      "params": {
+        "count": 10
+      },
+      "expectedFields": [
+        "campaigns",
+        "total_items"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "campaigns"
+        }
+      ]
+    },
+    {
+      "name": "Get Campaign Reports",
+      "tool": "get_campaign_reports",
+      "params": {
+        "campaign_id": "test_campaign_id"
+      },
+      "expectedFields": [
+        "id",
+        "type"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "id"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/news-api/server.json
+++ b/servers/news-api/server.json
@@ -1,0 +1,64 @@
+{
+  "name": "ai.nimbletools/news-api",
+  "version": "1.0.0",
+  "description": "News API: search articles, top headlines, breaking news from 80,000+ sources worldwide",
+  "category": "data-intelligence",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/news-api",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-news-api",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://newsapi.org/",
+  "license": "MIT",
+  "tags": [
+    "news",
+    "articles",
+    "headlines",
+    "journalism",
+    "media",
+    "breaking-news",
+    "current-events",
+    "sources",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "NEWS_API_KEY": {
+      "description": "News API key (get from https://newsapi.org/register)",
+      "required": true,
+      "secret": true,
+      "example": "your_news_api_key_here"
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/google-news",
+      "color": "#4285F4"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-news-api:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "200m",
+        "memory": "256Mi"
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "128Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/news-api/test.json
+++ b/servers/news-api/test.json
@@ -1,0 +1,77 @@
+{
+  "tests": [
+    {
+      "name": "Search Everything",
+      "tool": "search_everything",
+      "params": {
+        "q": "technology",
+        "language": "en",
+        "page_size": 5,
+        "sort_by": "publishedAt"
+      },
+      "expectedFields": [
+        "status",
+        "totalResults",
+        "articles"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "status",
+          "value": "ok"
+        },
+        {
+          "type": "exists",
+          "path": "articles"
+        }
+      ]
+    },
+    {
+      "name": "Get Top Headlines",
+      "tool": "get_top_headlines",
+      "params": {
+        "country": "us",
+        "page_size": 5
+      },
+      "expectedFields": [
+        "status",
+        "totalResults",
+        "articles"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "status",
+          "value": "ok"
+        },
+        {
+          "type": "exists",
+          "path": "articles"
+        }
+      ]
+    },
+    {
+      "name": "Get Sources",
+      "tool": "get_sources",
+      "params": {
+        "language": "en",
+        "country": "us"
+      },
+      "expectedFields": [
+        "status",
+        "sources"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "status",
+          "value": "ok"
+        },
+        {
+          "type": "exists",
+          "path": "sources"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/openai/server.json
+++ b/servers/openai/server.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/openai",
+  "version": "1.0.0",
+  "description": "OpenAI API: chat, embeddings, DALL-E, TTS, Whisper, vision, and moderation",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-openai",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://platform.openai.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-openai",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "OPENAI_API_KEY",
+          "description": "OpenAI API key for accessing GPT models (get key at platform.openai.com/api-keys)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "sk-..."
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "512Mi",
+          "cpu": "500m"
+        },
+        "requests": {
+          "memory": "256Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "OpenAI",
+        "category": "ai-ml",
+        "tags": [
+          "openai",
+          "gpt",
+          "gpt-4",
+          "chat",
+          "embeddings",
+          "dall-e",
+          "whisper",
+          "tts",
+          "vision",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/openai.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/openai.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-openai/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/openai/test.json
+++ b/servers/openai/test.json
@@ -1,0 +1,43 @@
+{
+  "environment": {
+    "OPENAI_API_KEY": "${OPENAI_API_KEY}"
+  },
+  "tests": [
+    {
+      "name": "Test chat completion",
+      "tool": "chat_completion",
+      "arguments": {
+        "messages": [
+          {"role": "user", "content": "Say 'test successful' and nothing else"}
+        ],
+        "model": "gpt-4o-mini",
+        "max_tokens": 10
+      },
+      "expect": {
+        "type": "text",
+        "contains": "test successful"
+      }
+    },
+    {
+      "name": "Test embedding creation",
+      "tool": "create_embedding",
+      "arguments": {
+        "text": "Hello, world!",
+        "model": "text-embedding-3-small"
+      },
+      "expect": {
+        "type": "object",
+        "hasKeys": ["embedding", "model", "dimensions"]
+      }
+    },
+    {
+      "name": "Test model listing",
+      "tool": "list_models",
+      "arguments": {},
+      "expect": {
+        "type": "array",
+        "minLength": 1
+      }
+    }
+  ]
+}

--- a/servers/openweathermap/server.json
+++ b/servers/openweathermap/server.json
@@ -1,0 +1,64 @@
+{
+  "name": "ai.nimbletools/openweathermap",
+  "version": "1.0.0",
+  "description": "OpenWeatherMap API: current weather, forecasts, alerts, air quality, and historical data",
+  "category": "data-intelligence",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/openweathermap",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-openweathermap",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://openweathermap.org/",
+  "license": "MIT",
+  "tags": [
+    "weather",
+    "forecast",
+    "climate",
+    "temperature",
+    "alerts",
+    "air-quality",
+    "meteorology",
+    "uv-index",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "OPENWEATHERMAP_API_KEY": {
+      "description": "OpenWeatherMap API key (get from https://openweathermap.org/api)",
+      "required": true,
+      "secret": true,
+      "example": "your_openweathermap_api_key_here"
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/openweathermap",
+      "color": "#EB6E4B"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-openweathermap:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "250m",
+        "memory": "256Mi"
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "128Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/openweathermap/test.json
+++ b/servers/openweathermap/test.json
@@ -1,0 +1,90 @@
+{
+  "tests": [
+    {
+      "name": "Get Current Weather for London",
+      "tool": "get_current_weather",
+      "params": {
+        "city": "London,GB",
+        "units": "metric"
+      },
+      "expectedFields": [
+        "coord",
+        "weather",
+        "main",
+        "wind",
+        "clouds",
+        "sys",
+        "name"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "main.temp"
+        },
+        {
+          "type": "exists",
+          "path": "weather"
+        },
+        {
+          "type": "equals",
+          "path": "name",
+          "value": "London"
+        }
+      ]
+    },
+    {
+      "name": "Get 5-Day Forecast for New York",
+      "tool": "get_forecast",
+      "params": {
+        "city": "New York,US",
+        "units": "imperial"
+      },
+      "expectedFields": [
+        "cod",
+        "list",
+        "city"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "cod",
+          "value": "200"
+        },
+        {
+          "type": "exists",
+          "path": "list"
+        },
+        {
+          "type": "exists",
+          "path": "city.name"
+        }
+      ]
+    },
+    {
+      "name": "Get Air Quality for Tokyo",
+      "tool": "get_air_quality",
+      "params": {
+        "lat": 35.6762,
+        "lon": 139.6503
+      },
+      "expectedFields": [
+        "coord",
+        "list"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "list"
+        },
+        {
+          "type": "exists",
+          "path": "coord.lat"
+        },
+        {
+          "type": "exists",
+          "path": "coord.lon"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/pdfco/server.json
+++ b/servers/pdfco/server.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/pdfco",
+  "version": "1.0.0",
+  "description": "PDF.co API: PDF manipulation, conversion, OCR, text extraction, and document automation",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-pdfco",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://pdf.co/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-pdfco",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "PDFCO_API_KEY",
+          "description": "PDF.co API key (get from https://app.pdf.co/dashboard)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_pdfco_api_key_here"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "512Mi",
+          "cpu": "500m"
+        },
+        "requests": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "PDF.co",
+        "category": "developer-tools",
+        "tags": [
+          "pdf",
+          "documents",
+          "ocr",
+          "conversion",
+          "automation",
+          "text-extraction",
+          "barcode",
+          "watermark",
+          "merge",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/pdfco.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/pdfco.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-pdfco/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/pdfco/test.json
+++ b/servers/pdfco/test.json
@@ -1,0 +1,55 @@
+{
+  "tests": [
+    {
+      "name": "PDF to Text",
+      "tool": "pdf_to_text",
+      "params": {
+        "url": "https://bytescout-com.s3.amazonaws.com/files/demo-files/cloud-api/pdf-to-text/sample.pdf"
+      },
+      "expectedFields": [
+        "body",
+        "url"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "body"
+        }
+      ]
+    },
+    {
+      "name": "PDF Info",
+      "tool": "pdf_info",
+      "params": {
+        "url": "https://bytescout-com.s3.amazonaws.com/files/demo-files/cloud-api/pdf-info/sample.pdf"
+      },
+      "expectedFields": [
+        "pageCount",
+        "info"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "pageCount"
+        }
+      ]
+    },
+    {
+      "name": "HTML to PDF",
+      "tool": "html_to_pdf",
+      "params": {
+        "html": "<html><body><h1>Test Document</h1><p>This is a test.</p></body></html>",
+        "name": "test.pdf"
+      },
+      "expectedFields": [
+        "url"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "url"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/pinecone/server.json
+++ b/servers/pinecone/server.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/pinecone",
+  "version": "1.0.0",
+  "description": "Pinecone API: vector database for embeddings, similarity search, and RAG applications",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-pinecone",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.pinecone.io/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-pinecone",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "PINECONE_API_KEY",
+          "description": "Pinecone API key (get from https://app.pinecone.io)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_pinecone_api_key"
+        },
+        {
+          "name": "PINECONE_ENVIRONMENT",
+          "description": "Pinecone environment (e.g., us-west1-gcp, us-east-1-aws)",
+          "isRequired": true,
+          "isSecret": false,
+          "example": "us-west1-gcp"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Pinecone",
+        "category": "infrastructure-data",
+        "tags": [
+          "pinecone",
+          "vector-database",
+          "embeddings",
+          "similarity-search",
+          "rag",
+          "semantic-search",
+          "ai",
+          "machine-learning",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/pinecone.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/pinecone.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-pinecone/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/pinecone/test.json
+++ b/servers/pinecone/test.json
@@ -1,0 +1,59 @@
+{
+  "tests": [
+    {
+      "name": "List Indexes",
+      "tool": "list_indexes",
+      "params": {},
+      "expectedFields": [
+        "indexes"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "indexes"
+        }
+      ]
+    },
+    {
+      "name": "Describe Index Stats",
+      "tool": "describe_index_stats",
+      "params": {
+        "index_name": "test-index"
+      },
+      "expectedFields": [
+        "dimension",
+        "indexFullness",
+        "totalVectorCount"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "dimension"
+        },
+        {
+          "type": "exists",
+          "path": "totalVectorCount"
+        }
+      ]
+    },
+    {
+      "name": "Query Vectors",
+      "tool": "query_vectors",
+      "params": {
+        "index_name": "test-index",
+        "vector": [0.1, 0.2, 0.3],
+        "top_k": 5,
+        "include_metadata": true
+      },
+      "expectedFields": [
+        "matches"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "matches"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/sendgrid/server.json
+++ b/servers/sendgrid/server.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/sendgrid",
+  "version": "1.0.0",
+  "description": "Email delivery and marketing automation via Twilio SendGrid API",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/Garoth/sendgrid-mcp",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://sendgrid.com",
+  "packages": [
+    {
+      "registryType": "remote",
+      "identifier": "sendgrid-pipedream",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.pipedream.com/app/sendgrid"
+      },
+      "environmentVariables": [
+        {
+          "name": "SENDGRID_API_KEY",
+          "description": "SendGrid API key (create at sendgrid.com/settings/api_keys - 69 characters)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "SG.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "deployment": {
+        "protocol": "http",
+        "hosted": "remote"
+      },
+      "display": {
+        "name": "SendGrid",
+        "category": "communication-collaboration",
+        "tags": [
+          "email",
+          "marketing",
+          "transactional-email",
+          "notifications",
+          "sendgrid",
+          "twilio",
+          "communications",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://sendgrid.com/favicon.ico",
+          "primaryColor": "#1A82E2"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/Garoth/sendgrid-mcp/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/sentry/server.json
+++ b/servers/sentry/server.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/sentry",
+  "version": "1.0.0",
+  "description": "Sentry API: error tracking, monitoring, releases, and performance analytics",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-sentry",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://sentry.io/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-sentry",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "SENTRY_AUTH_TOKEN",
+          "description": "Sentry auth token (get from https://sentry.io/settings/account/api/auth-tokens/)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_sentry_auth_token_here"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Sentry",
+        "category": "developer-tools",
+        "tags": [
+          "sentry",
+          "error-tracking",
+          "monitoring",
+          "debugging",
+          "performance",
+          "logging",
+          "apm",
+          "observability",
+          "developer-tools",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/sentry.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/sentry.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-sentry/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/sentry/test.json
+++ b/servers/sentry/test.json
@@ -1,0 +1,48 @@
+{
+  "tests": [
+    {
+      "name": "List Organizations",
+      "tool": "list_organizations",
+      "params": {},
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "type",
+          "path": "$",
+          "expectedType": "array"
+        }
+      ]
+    },
+    {
+      "name": "List Projects",
+      "tool": "list_projects",
+      "params": {
+        "organization_slug": "test-org"
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "type",
+          "path": "$",
+          "expectedType": "array"
+        }
+      ]
+    },
+    {
+      "name": "List Issues",
+      "tool": "list_issues",
+      "params": {
+        "organization_slug": "test-org",
+        "limit": 10
+      },
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "type",
+          "path": "$",
+          "expectedType": "array"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/stripe/server.json
+++ b/servers/stripe/server.json
@@ -1,0 +1,48 @@
+{
+  "name": "ai.nimbletools/stripe",
+  "version": "1.0.0",
+  "description": "Stripe payment API - manage customers, payments, subscriptions, invoices, and products",
+  "category": "business-finance",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/stripe",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-registry",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://stripe.com",
+  "license": "MIT",
+  "tags": [
+    "stripe",
+    "payments",
+    "billing",
+    "subscriptions",
+    "invoices",
+    "e-commerce"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "STRIPE_API_KEY": {
+      "description": "Stripe API key (get from https://stripe.com/dashboard/apikeys)",
+      "required": true,
+      "secret": true
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/stripe",
+      "color": "#635BFF"
+    },
+    "deployment": {
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-stripe:latest",
+      "port": 8000
+    },
+    "resources": {
+      "cpu": "100m",
+      "memory": "128Mi"
+    }
+  }
+}

--- a/servers/stripe/test.json
+++ b/servers/stripe/test.json
@@ -1,0 +1,104 @@
+{
+  "tests": [
+    {
+      "name": "List Customers",
+      "tool": "list_customers",
+      "params": {
+        "limit": 5
+      },
+      "expectedFields": [
+        "object",
+        "data",
+        "has_more",
+        "url"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "object",
+          "value": "list"
+        }
+      ]
+    },
+    {
+      "name": "List Charges",
+      "tool": "list_charges",
+      "params": {
+        "limit": 5
+      },
+      "expectedFields": [
+        "object",
+        "data",
+        "has_more",
+        "url"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "object",
+          "value": "list"
+        }
+      ]
+    },
+    {
+      "name": "List Subscriptions",
+      "tool": "list_subscriptions",
+      "params": {
+        "limit": 5
+      },
+      "expectedFields": [
+        "object",
+        "data",
+        "has_more",
+        "url"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "object",
+          "value": "list"
+        }
+      ]
+    },
+    {
+      "name": "List Products",
+      "tool": "list_products",
+      "params": {
+        "limit": 5
+      },
+      "expectedFields": [
+        "object",
+        "data",
+        "has_more",
+        "url"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "object",
+          "value": "list"
+        }
+      ]
+    },
+    {
+      "name": "List Invoices",
+      "tool": "list_invoices",
+      "params": {
+        "limit": 5
+      },
+      "expectedFields": [
+        "object",
+        "data",
+        "has_more",
+        "url"
+      ],
+      "assertions": [
+        {
+          "type": "equals",
+          "path": "object",
+          "value": "list"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/tmdb/server.json
+++ b/servers/tmdb/server.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/tmdb",
+  "version": "1.0.0",
+  "description": "TMDB API: movies, TV shows, cast info, ratings, and streaming availability from 1M+ titles",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-tmdb",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.themoviedb.org/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-tmdb",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "TMDB_API_KEY",
+          "description": "TMDB API key (get from https://www.themoviedb.org/settings/api)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_tmdb_api_key_here"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "TMDB",
+        "category": "data-intelligence",
+        "tags": [
+          "tmdb",
+          "movies",
+          "tv-shows",
+          "entertainment",
+          "streaming",
+          "cast",
+          "ratings",
+          "recommendations",
+          "cinema",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/tmdb.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/tmdb.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-tmdb/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/tmdb/test.json
+++ b/servers/tmdb/test.json
@@ -1,0 +1,64 @@
+{
+  "tests": [
+    {
+      "name": "Search Movies",
+      "tool": "search_movies",
+      "params": {
+        "query": "The Matrix",
+        "language": "en-US",
+        "page": 1
+      },
+      "expectedFields": [
+        "results",
+        "page",
+        "total_results"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "results"
+        },
+        {
+          "type": "exists",
+          "path": "page"
+        }
+      ]
+    },
+    {
+      "name": "Get Trending Movies",
+      "tool": "get_trending",
+      "params": {
+        "media_type": "movie",
+        "time_window": "day",
+        "language": "en-US"
+      },
+      "expectedFields": [
+        "results",
+        "page"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "results"
+        }
+      ]
+    },
+    {
+      "name": "Get Movie Genres",
+      "tool": "get_genres",
+      "params": {
+        "media_type": "movie",
+        "language": "en-US"
+      },
+      "expectedFields": [
+        "genres"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "genres"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/todoist/server.json
+++ b/servers/todoist/server.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://registry.nimbletools.ai/schemas/2025-09-22/nimbletools-server.schema.json",
+  "name": "ai.nimbletools/todoist",
+  "version": "1.0.0",
+  "description": "Todoist API: task management, projects, labels, and productivity automation",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-todoist",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://todoist.com/",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://docker.io",
+      "identifier": "nimbletools/mcp-todoist",
+      "version": "1.0.0",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://mcp.nimbletools.ai/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "TODOIST_API_TOKEN",
+          "description": "Todoist API token (get from https://todoist.com/app/settings/integrations/developer)",
+          "isRequired": true,
+          "isSecret": true,
+          "example": "your_todoist_api_token_here"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "ai.nimbletools.mcp/v1": {
+      "container": {
+        "healthCheck": {
+          "path": "/health",
+          "port": 8000
+        }
+      },
+      "capabilities": {
+        "tools": true,
+        "resources": false,
+        "prompts": false
+      },
+      "resources": {
+        "limits": {
+          "memory": "256Mi",
+          "cpu": "250m"
+        },
+        "requests": {
+          "memory": "128Mi",
+          "cpu": "100m"
+        }
+      },
+      "deployment": {
+        "protocol": "http",
+        "port": 8000,
+        "mcpPath": "/mcp"
+      },
+      "display": {
+        "name": "Todoist",
+        "category": "business-finance",
+        "tags": [
+          "todoist",
+          "tasks",
+          "todo",
+          "productivity",
+          "project-management",
+          "gtd",
+          "organization",
+          "planning",
+          "requires-api-key"
+        ],
+        "branding": {
+          "logoUrl": "https://static.nimbletools.ai/logos/todoist.png",
+          "iconUrl": "https://static.nimbletools.ai/icons/todoist.png"
+        },
+        "documentation": {
+          "readmeUrl": "https://raw.githubusercontent.com/NimbleBrainInc/mcp-todoist/main/README.md"
+        }
+      }
+    }
+  }
+}

--- a/servers/todoist/test.json
+++ b/servers/todoist/test.json
@@ -1,0 +1,43 @@
+{
+  "tests": [
+    {
+      "name": "List Tasks",
+      "tool": "list_tasks",
+      "params": {},
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "type",
+          "path": "$",
+          "expectedType": "array"
+        }
+      ]
+    },
+    {
+      "name": "List Projects",
+      "tool": "list_projects",
+      "params": {},
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "type",
+          "path": "$",
+          "expectedType": "array"
+        }
+      ]
+    },
+    {
+      "name": "List Labels",
+      "tool": "list_labels",
+      "params": {},
+      "expectedFields": [],
+      "assertions": [
+        {
+          "type": "type",
+          "path": "$",
+          "expectedType": "array"
+        }
+      ]
+    }
+  ]
+}

--- a/servers/twilio/server.json
+++ b/servers/twilio/server.json
@@ -1,0 +1,68 @@
+{
+  "name": "ai.nimbletools/twilio",
+  "version": "1.0.0",
+  "description": "Twilio API: send SMS, WhatsApp messages, make calls, and manage communication",
+  "category": "communication-collaboration",
+  "status": "active",
+  "homepage": "https://github.com/NimbleBrainInc/mcp-registry/tree/main/servers/twilio",
+  "repository": {
+    "url": "https://github.com/NimbleBrainInc/mcp-registry",
+    "source": "github",
+    "branch": "main"
+  },
+  "websiteUrl": "https://www.twilio.com/",
+  "license": "MIT",
+  "tags": [
+    "twilio",
+    "sms",
+    "whatsapp",
+    "voice",
+    "calls",
+    "messaging",
+    "communication",
+    "notifications",
+    "requires-api-key"
+  ],
+  "transport": {
+    "type": "streamable-http",
+    "url": "https://mcp.nimbletools.ai/mcp"
+  },
+  "environmentVariables": {
+    "TWILIO_ACCOUNT_SID": {
+      "description": "Twilio Account SID (get from https://console.twilio.com)",
+      "required": true,
+      "secret": true
+    },
+    "TWILIO_AUTH_TOKEN": {
+      "description": "Twilio Auth Token (get from https://console.twilio.com)",
+      "required": true,
+      "secret": true
+    }
+  },
+  "_meta": {
+    "display": {
+      "icon": "https://cdn.simpleicons.org/twilio",
+      "color": "#F22F46"
+    },
+    "deployment": {
+      "protocol": "http",
+      "registry": "ghcr.io",
+      "image": "ghcr.io/nimblebraininc/mcp-twilio:latest",
+      "port": 8000,
+      "mcpPath": "/mcp"
+    },
+    "resources": {
+      "limits": {
+        "cpu": "200m",
+        "memory": "256Mi"
+      },
+      "requests": {
+        "cpu": "100m",
+        "memory": "128Mi"
+      }
+    },
+    "capabilities": {
+      "tools": true
+    }
+  }
+}

--- a/servers/twilio/test.json
+++ b/servers/twilio/test.json
@@ -1,0 +1,68 @@
+{
+  "tests": [
+    {
+      "name": "Get Account Balance",
+      "tool": "get_account_balance",
+      "params": {},
+      "expectedFields": [
+        "account_sid",
+        "balance",
+        "currency"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "account_sid"
+        },
+        {
+          "type": "exists",
+          "path": "currency"
+        }
+      ]
+    },
+    {
+      "name": "List Phone Numbers",
+      "tool": "list_phone_numbers",
+      "params": {
+        "page_size": 5
+      },
+      "expectedFields": [
+        "incoming_phone_numbers",
+        "uri",
+        "first_page_uri",
+        "next_page_uri",
+        "previous_page_uri",
+        "page",
+        "page_size"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "incoming_phone_numbers"
+        }
+      ]
+    },
+    {
+      "name": "List Messages",
+      "tool": "list_messages",
+      "params": {
+        "page_size": 5
+      },
+      "expectedFields": [
+        "messages",
+        "uri",
+        "first_page_uri",
+        "next_page_uri",
+        "previous_page_uri",
+        "page",
+        "page_size"
+      ],
+      "assertions": [
+        {
+          "type": "exists",
+          "path": "messages"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Copied server.json and test.json from individual repos:
- asana, stripe, openai, abstract-api, airtable
- alpha-vantage, brave-search, claude, clickhouse, clickup
- coingecko, context7, deepl, gemini, gitlab
- huggingface, linear, mailchimp, news-api, openweathermap
- pdfco, pinecone, sendgrid (server.json only), sentry, tmdb
- todoist, twilio

Note: github repo already existed and was not processed.